### PR TITLE
Update nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4005,9 +4005,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "sharp": "0.35.0",
     "postcss": "$postcss"
   }


### PR DESCRIPTION
Updates the existing nanoid override and lockfile from 3.3.17 to 3.3.18 to resolve GHSA-2v37-7h3g-55p8. The selected release was published 2026-08-07, more than 24 hours before this update.

Validation:
- npm ci: passed
- npm audit: 2 high to 0
- Baseline and updated typecheck: same existing TS18046 failure
- Baseline and updated build: same missing MongoDB URI failure
- Baseline and updated lint: same unconfigured interactive ESLint prompt